### PR TITLE
Prevent accidental nil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Muddle
+        uses: demonnic/build-with-muddler@v1.3
+
+      - name: Upload MPackage
+        uses: actions/upload-artifact@v2
+        with:
+          name: EMCOChat
+          path: build/tmp/
+

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "EMCOChat",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "author": "Demonnic",
   "title": "Premade tabbed chat using EMCO",
   "icon": "computer.png",

--- a/src/scripts/EMCO/Code.lua
+++ b/src/scripts/EMCO/Code.lua
@@ -17,7 +17,7 @@ local inactiveStyle = Geyser.StyleSheet:new(f [[
   background-color: {demonnic.config.inactiveColor};
 ]], baseStyle)
 
-local chatEMCO
+local chatEMCO = demonnic.chat
 local EMCOfilename = getMudletHomeDir() .. "/EMCO/EMCOPrebuiltChat.lua"
 local confFile = getMudletHomeDir() .. "/EMCO/EMCOPrebuiltExtraOptions.lua"
 


### PR DESCRIPTION
Prevent potential problem where the script which defines the helper functions/etc lose track of the local chatEMCO due to an oversight when declaring it.

Resolves https://github.com/demonnic/EMCO/issues/11