### PR TITLE
New aliases for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ If you want to send lines to the EMCO in code yourself, you can use `demonnic.ch
   * hide the EMCO
 * `emco load`
   * loads your config from disk
+* `emco lock`
+  * locks the EMCO in place
 * `emco notify <tabName>`
   * turn on OS notifications for tabName
 * `emco remtab <tabname>`
@@ -60,6 +62,10 @@ If you want to send lines to the EMCO in code yourself, you can use `demonnic.ch
   * show the EMCO
 * `emco timestamp <true|false>`
   * turn timestamps on/off
+* `emco title <new title>`
+  * Set the title at the top of the EMCO Chat window. "Tabbed Chat" is the default starting title.
+* `emco unlock`
+  * Unlocks the EMCO window so you can move and resize it again
 * `emco ungag <pattern>`
   * remove a gag pattern
 * `emco unnotify <tabName>`

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "EMCOChat",
-  "version": "2.8.5",
+  "version": "2.9.0",
   "author": "Demonnic",
   "title": "Premade tabbed chat using EMCO",
   "icon": "computer.png",

--- a/src/aliases/EMCO/aliases.json
+++ b/src/aliases/EMCO/aliases.json
@@ -46,5 +46,17 @@
   {
     "name": "emco update",
     "regex": "^emco update$"
+  },
+  {
+    "name": "emco title",
+    "regex": "^emco title (.+)"
+  },
+  {
+    "name": "emco lock",
+    "regex": "^emco lock$"
+  },
+  {
+    "name": "emco unlock",
+    "regex": "^emco unlock$"
   }
 ]

--- a/src/aliases/EMCO/emco_color.lua
+++ b/src/aliases/EMCO/emco_color.lua
@@ -5,4 +5,4 @@ if not ok then
   echo(err)
   return
 end
-echo(f"Set {matches[2]} to {matches[3]}")
+echo(f"Set color for {matches[2]} to {matches[3]}")

--- a/src/aliases/EMCO/emco_lock.lua
+++ b/src/aliases/EMCO/emco_lock.lua
@@ -1,0 +1,1 @@
+demonnic.container:lockContainer()

--- a/src/aliases/EMCO/emco_title.lua
+++ b/src/aliases/EMCO/emco_title.lua
@@ -1,0 +1,5 @@
+local title = matches[2]
+if title == "clear" then
+  title = ""
+end
+demonnic.container:setTitle(title)

--- a/src/aliases/EMCO/emco_unlock.lua
+++ b/src/aliases/EMCO/emco_unlock.lua
@@ -1,0 +1,1 @@
+demonnic.container:unlockContainer()

--- a/src/scripts/EMCO/Code.lua
+++ b/src/scripts/EMCO/Code.lua
@@ -1,4 +1,4 @@
-local defaultConfig = {activeColor = "black", inactiveColor = "black", activeBorder = "green", activeText = "green", inactiveText = "grey", background = "black", windowBorder = "green"}
+local defaultConfig = {activeColor = "black", inactiveColor = "black", activeBorder = "green", activeText = "green", inactiveText = "grey", background = "black", windowBorder = "green", title = "green"}
 local emco = require("@PKGNAME@.emco")
 emco.cmdLineStyleSheet = nil
 demonnic = demonnic or {}
@@ -22,7 +22,7 @@ local adjLabelStyle = Geyser.StyleSheet:new(f[[
   border-color: {demonnic.config.windowBorder};
   border-radius: 4px;]])
 
-  local default_constraints = {name = "EMCOPrebuiltChatContainer", x = "-25%", y = "-60%", width = "25%", height = "60%"}
+local default_constraints = {name = "EMCOPrebuiltChatContainer", x = "-25%", y = "-60%", width = "25%", height = "60%", titleText = "Tabbed Chat"}
 
 
 local chatEMCO = demonnic.chat
@@ -75,6 +75,7 @@ function demonnic.helpers.retheme()
   local als = adjLabelStyle:getCSS()
   demonnic.container.adjLabelstyle = als
   demonnic.container.adjLabel:setStyleSheet(als)
+  demonnic.container:setTitle(demonnic.container.titleText, demonnic.config.title)
   chatEMCO.activeTabCSS = activeStyle:getCSS()
   chatEMCO.inactiveTabCSS = inactiveStyle:getCSS()
   chatEMCO:setActiveTabFGColor(demonnic.config.activeText)
@@ -104,6 +105,9 @@ function demonnic.helpers.load()
     local conf = {}
     table.load(confFile, conf)
     demonnic.config = table.update(demonnic.config, conf)
+    for option, value in pairs(defaultConfig) do
+      demonnic.config[option] = demonnic.config[option] or value
+    end
   end
   if io.exists(EMCOfilename) then
     chatEMCO:hide()


### PR DESCRIPTION
Adds:

* `emco lock`
  * locks the EMCO window's size and position
* `emco unlock`
  * makes it so you can move and resize the window again
* `emco title <new title>`
  * Sets the title of the EMCO chat window
* `emco color title <color>`
  * set the color of the title